### PR TITLE
Add ability to override the extension used on the output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ swig: {
         autoescape: true
     },
     dest: "www/",
+    generatedExtension: "html",
     src: ['**/*.swig'],
     generateSitemap: true,
     generateRobotstxt: true,
@@ -69,6 +70,8 @@ You need to give the relative path to the output html file for this to work.
 
 Path and base name of the source template file are available in `tplFile` variable, `tplFile.path` for
 the path and `tplFile.basename` for the basename.
+
+To override the default extension of `.html` by specifying the ```generatedExtension``` (without the period) in your config.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/tasks/swig.js
+++ b/tasks/swig.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
         var dirName = path.dirname(file).split('/'),
             destPath = dirName.splice(1, dirName.length).join('/'),
             outputFile = path.basename(file, '.swig'),
-            htmlFile = config.data.dest + '/' + destPath + '/' + outputFile + '.html',
+            ext = config.data.generatedExtension ? config.data.generatedExtension : 'html',
+            htmlFile = config.data.dest + '/' + destPath + '/' + outputFile + '.' + ext,
             tplVars = {},
             contextVars = {};
 


### PR DESCRIPTION
## Included with this pull request

By specifying the 'generatedExtension' in the config you can have the generated file use a different extension.
## Not included with this pull request

In the future it would be nice to take this further and be able to specify different extensions for different files...

Or have it look for a subextension.  Example:
index.swig -> index.html
index.xml.swig -> index.xml
