### PR TITLE
Add support for flat trees.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,13 @@ module.exports = function (grunt) {
           '_DEFAULT_': '0.7',
           'fixtures/index.html': 0.8
         }
+      },
+      flattern: {
+        dest: 'test/dest',
+        src: ['test/fixtures/path/to/flatterntest.swig'],
+        flattern: true,
+        generateSitemap: false,
+        generateRobotstxt: false
       }
     },
     jshint: {

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ swig: {
     },
     dest: "www/",
     src: ['**/*.swig'],
+    flattern: false,
     generateSitemap: true,
     generateRobotstxt: true,
     siteUrl: 'http://mydomain.net/',
@@ -69,6 +70,9 @@ You need to give the relative path to the output html file for this to work.
 
 Path and base name of the source template file are available in `tplFile` variable, `tplFile.path` for
 the path and `tplFile.basename` for the basename.
+
+The `flattern` flag will just place the compiled swig files inside `dest` directory without using
+directory tree as it was in `src` folder.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/tasks/swig.js
+++ b/tasks/swig.js
@@ -40,6 +40,10 @@ module.exports = function(grunt) {
             tplVars = {},
             contextVars = {};
 
+        if ( config.data.flattern ) {
+            htmlFile = config.data.dest + '/' + outputFile + '.html';
+        }
+
         try {
           tplVars = grunt.file.readJSON(path.dirname(file) + '/' + outputFile + ".json");
         } catch(err) {

--- a/test/fixtures/path/to/flatterntest.swig
+++ b/test/fixtures/path/to/flatterntest.swig
@@ -1,0 +1,1 @@
+I should be in the [dest] root as HTML file.

--- a/test/swig_test.js
+++ b/test/swig_test.js
@@ -45,4 +45,8 @@ describe('grunt-swig', function() {
     helpers.assertFile('test/dest/robots.txt');
   });
 
+  it('should exist in dest/flattern/flatterntest.html', function(){
+  	helpers.assertFile('test/dest/flatterntest.html');
+  });
+
 });


### PR DESCRIPTION
You cannot decide if you just want all the *.swig files into one tree, or using the directory tree inside the "src" folder.

So, a "flattern" flag will just accomplish this.
This would be an awesome feature. Please merge this ASAP :)

Thanks in advice.
